### PR TITLE
Fixes discovered in lts-15.0 update

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -73,7 +73,9 @@ library:
   dependencies:
     - aeson
     - containers
+    - http-client
     - http-conduit
+    - http-types
     - optparse-applicative
     - text
     - these

--- a/src/Rcl/Changelog.hs
+++ b/src/Rcl/Changelog.hs
@@ -1,6 +1,5 @@
 module Rcl.Changelog
   ( getChangelogFromTo
-  , changeLogLinesTo
   )
 where
 
@@ -9,39 +8,48 @@ import RIO
 import Data.Text (pack, unpack)
 import qualified Data.Text as T
 import Data.Version
+import Network.HTTP.Client (HttpExceptionContent(..))
 import Network.HTTP.Simple
+import Network.HTTP.Types.Status (status404)
 import Rcl.App
 import Rcl.PackageName
 
 getChangelogFromTo :: PackageName -> Version -> Version -> RIO App Text
-getChangelogFromTo name version oldVersion = do
-  req <-
-    parseRequestThrow
-    $ "http://hackage.haskell.org/package/"
+getChangelogFromTo name version oldVersion = handleJust notFound pure $ do
+  req <- parseRequestThrow $ changelogUrl name version
+  changelogFromTo version oldVersion . getResponseBody <$> httpBS req
+
+notFound :: HttpException -> Maybe Text
+notFound = \case
+  HttpExceptionRequest _ (StatusCodeException resp _)
+    | getResponseStatus resp == status404 -> Just "Changelog not found"
+  _ -> Nothing
+
+changelogUrl :: PackageName -> Version -> String
+changelogUrl "base" _ =
+  "https://raw.githubusercontent.com/ghc/ghc/master/libraries/base/changelog.md"
+changelogUrl name version =
+  "http://hackage.haskell.org/package/"
     <> unpack (unPackageName name)
     <> "-"
     <> showVersion version
     <> "/changelog"
 
+changelogFromTo :: Version -> Version -> ByteString -> Text
+changelogFromTo version oldVersion =
   T.strip
     . T.unlines
-    . drop 1 -- Hackage's automatic title
-    . changeLogLinesTo oldVersion
-    . getResponseBody
-    <$> httpBS req
+    . takeWhile (not . marksVersion oldVersion)
+    . dropWhile (not . marksVersion version)
+    . T.lines
+    . T.replace "\r\n" "\n"
+    . decodeUtf8With lenientDecode
 
-changeLogLinesTo :: Version -> ByteString -> [Text]
-changeLogLinesTo version =
-  takeWhile (not . marksVersion) . T.lines . decodeUtf8With lenientDecode
- where
-  -- Yes, this will need futzing as we discover odd changelog formats, but it's
-  -- not too bad so far.
-  marksVersion ln =
-    tversion
-      `T.isSuffixOf` ln
-      || (tversion <> " ")
-      `T.isInfixOf` ln
-      || (tversion <> ",")
-      `T.isInfixOf` ln
-
-  tversion = pack $ showVersion version
+marksVersion :: Version -> Text -> Bool
+marksVersion version ln = or
+  [ tversion `T.isSuffixOf` ln
+  , (tversion <> " ") `T.isInfixOf` ln
+  , (tversion <> ",") `T.isInfixOf` ln
+  , ("[" <> tversion <> "]") `T.isInfixOf` ln
+  ]
+  where tversion = pack $ showVersion version


### PR DESCRIPTION
- Handle base Changelog specially

  - Use the GitHub URL
  - Update Changelog "parsing" to target between new/old, not just seek
    from top to old

- Don't error on missing Changelogs

  This is not uncommon, so we shouldn't crash.

- Look for linked version headers

  Seems:

      ... [$version] ...

  Is another common convention for Changelogs.

- Handle CRLF content

And minor style changes.