### PR TITLE
Fix Stackage diff parser

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,4 +1,7 @@
 - brittany
-- hlint
+- hlint:
+    include:
+      - "**/*.hs"
+      - "!src/Rcl/SillyArrayMap.hs" # TypeApplications breaks apply-refact
 - shfmt
 - stylish-haskell

--- a/package.yaml
+++ b/package.yaml
@@ -93,3 +93,13 @@ executables:
       - -threaded
       - -rtsopts
       - -with-rtsopts=-N
+
+tests:
+  spec:
+    main: Spec.hs
+    source-dirs: test
+    dependencies:
+      - aeson
+      - hspec
+      - rcl
+      - unordered-containers

--- a/package.yaml
+++ b/package.yaml
@@ -80,6 +80,7 @@ library:
     - text
     - these
     - unordered-containers
+    - vector
 
 executables:
   rcl:

--- a/src/Rcl/ChangedPackage.hs
+++ b/src/Rcl/ChangedPackage.hs
@@ -17,6 +17,8 @@ import Network.HTTP.Simple
 import Rcl.App
 import Rcl.PackageName
 import Rcl.Resolver
+import Rcl.SillyArrayMap (SillyArrayMap)
+import qualified Rcl.SillyArrayMap as SillyArrayMap
 
 -- | Details for a changed package
 data ChangedPackage = ChangedPackage
@@ -32,7 +34,7 @@ data ChangedPackage = ChangedPackage
 
 data ResolverDiff = ResolverDiff
   { comparing :: [Text]
-  , diff :: HashMap PackageName (HashMap Resolver Version)
+  , diff :: SillyArrayMap PackageName (HashMap Resolver Version)
   }
   deriving stock Generic
   deriving anyclass FromJSON
@@ -41,7 +43,7 @@ getResolverDiff :: Resolver -> Resolver -> RIO App [ChangedPackage]
 getResolverDiff fromResolver toResolver = do
   req <- parseRequestThrow $ resolverDiffUrl fromResolver toResolver
   mapMaybe (uncurry changedPackage)
-    . HashMap.toList
+    . SillyArrayMap.toList
     . diff
     . getResponseBody
     <$> httpJSON req

--- a/src/Rcl/SillyArrayMap.hs
+++ b/src/Rcl/SillyArrayMap.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE TypeApplications #-}
+
+-- | Stackage changed its JSON representation for package differences
+--
+-- It used to be nested objects:
+--
+-- @
+-- { diff:
+--   { some-package:    { lts-x: version-x, lts-y: version-y }
+--   , another-package: { lts-x: version-x, lts-y: version-y }
+--   , ...
+--   }
+-- }
+-- @
+--
+-- which was very easy to work with in Haskell (map of maps).
+--
+-- Now it's this:
+--
+-- @
+-- { diff:
+--   [ ["some-package",    { lts-x: version-x, lts-y: version-y }]
+--   , ["another-package", { lts-x: version-x, lts-y: version-y }]
+--   , ...
+--   ]
+-- }
+-- @
+--
+-- Which is /not/ easy to work with in Haskell (list of heterogenious list).
+--
+-- I guess is nicer for JavaScript? Any, I'm representing this silly type and
+-- JSON parser here, to isolate the mess. It allows a drop-in change in my main
+-- type to fix the parsing.
+--
+module Rcl.SillyArrayMap
+  ( SillyArrayMap
+  , toList
+  )
+where
+
+import RIO hiding (toList)
+
+import Data.Aeson
+import Data.Aeson.Types (Parser)
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Vector as V
+import Unsafe.Coerce (unsafeCoerce)
+
+newtype SillyArrayMap k v = SillyArrayMap
+  { unSillyArrayMap :: HashMap k v
+  }
+
+toList :: SillyArrayMap k v -> [(k, v)]
+toList = HashMap.toList . unSillyArrayMap
+
+instance (Eq k, Hashable k, FromJSONKey k, FromJSON v) => FromJSON (SillyArrayMap k v) where
+  parseJSON =
+    withArray "SillyArrayMap"
+      $ fmap (SillyArrayMap . HashMap.fromList)
+      . traverse parseSillyArrayElem
+      . V.toList
+
+parseSillyArrayElem :: (FromJSONKey k, FromJSON v) => Value -> Parser (k, v)
+parseSillyArrayElem = withArray "SillyArrayMapElement" $ go . V.toList
+ where
+  go = \case
+    [k, v] -> (,) <$> parseJSONKey k <*> parseJSON v
+    _ -> fail "Silly Array element wasn't exactly two keys"
+
+parseJSONKey :: forall k . FromJSONKey k => Value -> Parser k
+parseJSONKey v = case fromJSONKey @k of
+  FromJSONKeyCoerce _ -> withText' $ pure . unsafeCoerce
+  FromJSONKeyText f -> withText' $ pure . f
+  FromJSONKeyTextParser f -> withText' f
+  FromJSONKeyValue f -> f v
+  where withText' f = withText "Key" f v

--- a/src/Rcl/SillyArrayMap.hs
+++ b/src/Rcl/SillyArrayMap.hs
@@ -28,7 +28,7 @@
 --
 -- Which is /not/ easy to work with in Haskell (list of heterogenious list).
 --
--- I guess is nicer for JavaScript? Any, I'm representing this silly type and
+-- I guess is nicer for JavaScript? Anyway, I'm representing this silly type and
 -- JSON parser here, to isolate the mess. It allows a drop-in change in my main
 -- type to fix the parsing.
 --

--- a/test/Rcl/SillyArrayMapSpec.hs
+++ b/test/Rcl/SillyArrayMapSpec.hs
@@ -1,0 +1,40 @@
+module Rcl.SillyArrayMapSpec
+  ( spec
+  )
+where
+
+import RIO
+
+import Data.Aeson
+import qualified Data.HashMap.Strict as HashMap
+import Data.Version
+import Rcl.PackageName
+import Rcl.Resolver
+import qualified Rcl.SillyArrayMap as SillyArrayMap
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "FromJSON" $ do
+    it "parses this silly diff syntax" $ do
+      let
+        sillyJson = mconcat
+          [ "["
+          , "  [\"foo\", {\"lts-x\": \"1.2.0\", \"lts-y\": \"1.3.0\"}],"
+          , "  [\"bar\", {\"lts-x\": \"2.2.0\", \"lts-y\": \"2.2.1\"}]"
+          , "]"
+          ]
+
+        decoded :: Either String [(PackageName, HashMap Resolver Version)]
+        decoded = SillyArrayMap.toList <$> eitherDecode sillyJson
+
+      decoded `shouldBe` Right
+        [ ( "foo"
+          , HashMap.fromList
+            [("lts-x", makeVersion [1, 2, 0]), ("lts-y", makeVersion [1, 3, 0])]
+          )
+        , ( "bar"
+          , HashMap.fromList
+            [("lts-x", makeVersion [2, 2, 0]), ("lts-y", makeVersion [2, 2, 1])]
+          )
+        ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,2 @@
+{-# OPTIONS_GHC -fno-warn-missing-export-lists #-}
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
Stackage changed its JSON representation for package differences

It used to be nested objects:

```js
{ diff:
  { some-package:    { lts-x: version-x, lts-y: version-y }
  , another-package: { lts-x: version-x, lts-y: version-y }
  , ...
  }
}
```

which was *very easy* to work with in Haskell (map of maps).

Now it's this:

```js
{ diff:
  [ ["some-package",    { lts-x: version-x, lts-y: version-y }]
  , ["another-package", { lts-x: version-x, lts-y: version-y }]
  , ...
  ]
}
```

Which is not easy to work with in Haskell (list of heterogeneous list).

I guess is nicer for JavaScript? Anyway, I'm representing this silly type and
JSON parser in its own module, to isolate the mess. It allows a drop-in change
in the main type to fix parsing.