### PR TITLE
Display version diff when available

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,4 +16,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ hashFiles('stack.yaml') }}-
             ${{ runner.os }}-
-      - uses: freckle/stack-action@v1.1
+      - uses: freckle/stack-action@v3

--- a/package.yaml
+++ b/package.yaml
@@ -27,44 +27,31 @@ ghc-options:
 
 default-extensions:
   - BangPatterns
-  - BinaryLiterals
-  - ConstraintKinds
   - DataKinds
-  - DefaultSignatures
   - DeriveAnyClass
-  - DeriveDataTypeable
   - DeriveFoldable
   - DeriveFunctor
   - DeriveGeneric
+  - DeriveLift
   - DeriveTraversable
   - DerivingStrategies
-  - DoAndIfThenElse
-  - EmptyDataDecls
-  - ExistentialQuantification
   - FlexibleContexts
   - FlexibleInstances
-  - FunctionalDependencies
   - GADTs
   - GeneralizedNewtypeDeriving
-  - InstanceSigs
-  - KindSignatures
   - LambdaCase
   - MultiParamTypeClasses
-  - MultiWayIf
-  - NamedFieldPuns
   - NoImplicitPrelude
+  - NoMonomorphismRestriction
   - OverloadedStrings
-  - PartialTypeSignatures
-  - PatternGuards
-  - PolyKinds
+  - QuasiQuotes
   - RankNTypes
   - RecordWildCards
   - ScopedTypeVariables
   - StandaloneDeriving
-  - TupleSections
+  - TypeApplications
   - TypeFamilies
-  - TypeSynonymInstances
-  - ViewPatterns
+
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -125,5 +125,6 @@ tests:
     dependencies:
       - aeson
       - hspec
+      - QuickCheck
       - rcl
       - unordered-containers

--- a/src/Rcl/SillyArrayMap.hs
+++ b/src/Rcl/SillyArrayMap.hs
@@ -69,7 +69,7 @@ parseSillyArrayElem = withArray "SillyArrayMapElement" $ go . V.toList
 
 parseJSONKey :: forall k . FromJSONKey k => Value -> Parser k
 parseJSONKey v = case fromJSONKey @k of
-  FromJSONKeyCoerce _ -> withText' $ pure . unsafeCoerce
+  FromJSONKeyCoerce{} -> withText' $ pure . unsafeCoerce
   FromJSONKeyText f -> withText' $ pure . f
   FromJSONKeyTextParser f -> withText' f
   FromJSONKeyValue f -> f v

--- a/src/Rcl/VersionDiff.hs
+++ b/src/Rcl/VersionDiff.hs
@@ -1,0 +1,26 @@
+module Rcl.VersionDiff
+  ( versionDiff
+  , VersionDiff(..)
+  ) where
+
+import RIO
+
+import Data.Version (Version, showVersion)
+
+versionDiff :: Version -> Version -> VersionDiff
+versionDiff fromV toV = VersionDiff
+  { commonPrefix = take prefixLength strFrom
+  , fromSuffix = drop prefixLength strFrom
+  , toSuffix = drop prefixLength strTo
+  }
+ where
+  strFrom = showVersion fromV
+  strTo = showVersion toV
+  prefixLength = length $ takeWhile id $ zipWith (==) strFrom strTo
+
+data VersionDiff = VersionDiff
+  { commonPrefix :: String
+  , fromSuffix :: String
+  , toSuffix :: String
+  }
+  deriving (Eq, Show)

--- a/src/Rcl/Web/Templates.hs
+++ b/src/Rcl/Web/Templates.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
-
 module Rcl.Web.Templates
   ( root
   , failure

--- a/src/Rcl/Web/Templates.hs
+++ b/src/Rcl/Web/Templates.hs
@@ -14,6 +14,7 @@ import qualified RIO.Text as T
 import Rcl.PackageName
 import Rcl.Resolver
 import Rcl.Run (Change(..), Changes(..))
+import Rcl.VersionDiff (VersionDiff(..), versionDiff)
 import qualified Text.MMark as MMark
 import qualified Text.Megaparsec as M
 
@@ -122,17 +123,11 @@ versionChange mFromV toV = do
   case mFromV of
     Nothing -> span_ $ toHtml $ pack (showVersion toV)
     Just fromV -> do
-      let
-        strFrom = showVersion fromV
-        strTo = showVersion toV
-        prefixLength = length $ takeWhile id $ zipWith (==) strFrom strTo
-        prefix = take prefixLength strFrom
-        fromSuffix = drop prefixLength strFrom
-        toSuffix = drop prefixLength strTo
-      toHtml prefix
+      let VersionDiff {..} = versionDiff fromV toV
+      toHtml commonPrefix
       span_ [class_ "from"] $ toHtml fromSuffix
       " " <> toHtmlRaw @String "&#8594;" <> " "
-      toHtml prefix
+      toHtml commonPrefix
       span_ [class_ "to"] $ toHtml toSuffix
 
 changeLogDetails :: Text -> Html ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-16.27
+resolver: lts-18.28

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 533252
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/27.yaml
-    sha256: c2aaae52beeacf6a5727c1010f50e89d03869abfab6d2c2658ade9da8ed50c73
-  original: lts-16.27
+    size: 590100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
+  original: lts-18.28

--- a/test/Rcl/VersionDiffSpec.hs
+++ b/test/Rcl/VersionDiffSpec.hs
@@ -1,0 +1,56 @@
+module Rcl.VersionDiffSpec
+  ( spec
+  ) where
+
+import RIO
+
+import Data.Version
+import Rcl.VersionDiff
+import Test.Hspec
+import Test.QuickCheck
+
+spec :: Spec
+spec = do
+  describe "versionDiff" $ do
+    it "pickle and unpickle" $ property $ \(v1, v2) ->
+      let VersionDiff {..} = versionDiff v1 v2
+      in
+        (showVersion v1 == (commonPrefix <> fromSuffix))
+          && (showVersion v2 == (commonPrefix <> toSuffix))
+
+    it "diffs a minor change"
+      $ let diff = versionDiff (makeVersion [1, 2, 3]) (makeVersion [1, 2, 4])
+        in
+          diff `shouldBe` VersionDiff
+            { commonPrefix = "1.2."
+            , fromSuffix = "3"
+            , toSuffix = "4"
+            }
+
+    it "diffs a major change"
+      $ let diff = versionDiff (makeVersion [1, 1, 0]) (makeVersion [1, 2, 0])
+        in
+          diff `shouldBe` VersionDiff
+            { commonPrefix = "1."
+            , fromSuffix = "1.0"
+            , toSuffix = "2.0"
+            }
+
+    it "diffs an epic change"
+      $ let diff = versionDiff (makeVersion [4, 1, 0]) (makeVersion [5, 1, 0])
+        in
+          diff `shouldBe` VersionDiff
+            { commonPrefix = ""
+            , fromSuffix = "4.1.0"
+            , toSuffix = "5.1.0"
+            }
+
+    it "diffs a place change"
+      $ let
+          diff = versionDiff (makeVersion [2, 12, 0]) (makeVersion [2, 14, 0])
+        in
+          diff `shouldBe` VersionDiff
+            { commonPrefix = "2.1"
+            , fromSuffix = "2.0"
+            , toSuffix = "4.0"
+            }


### PR DESCRIPTION
Instead of displaying the two different versions on separate lines, display them
with red and green highlights to draw attention to the difference. This reduces
the vertical footprint of the page and makes it more scannable.

![image](https://user-images.githubusercontent.com/545655/164304835-f9b0b21e-8ae4-43b5-984f-769b42856e7e.png)
