### PR TITLE
Request plain/text from hackage

### DIFF
--- a/src/Rcl/Changelog.hs
+++ b/src/Rcl/Changelog.hs
@@ -22,7 +22,7 @@ getChangelogFromTo
 getChangelogFromTo name version oldVersion = handleJust notFound pure $ do
   let
     url = changelogUrl name version
-    req = parseRequest_ url
+    req = setRequestHeaders [("Accept", "text/plain")] $ parseRequest_ url
   logDebug
     $ "Fetching changelog for "
     <> display name


### PR DESCRIPTION
Hackage has started rendering changlogs to html if the `text/html` accept header
is provided. Setting this header to `text/plain` pulls back the expected
content.